### PR TITLE
Additional datatypes / Refactoring

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 {erl_opts, [debug_info, warnings_as_errors, {platform_define, "^[0-9]+",
                                              namespaced_types}]}.
 {deps, [
-        {protobuffs, {git, "git://github.com/basho/erlang_protobuffs.git", {tag, "0.8.1p5"}}}
+        {protobuffs, {git, "git://github.com/basho/erlang_protobuffs.git", {tag, "0.9.0"}}}
        ]}.
 
 {xref_checks, [undefined_function_calls, undefined_functions,
@@ -10,7 +10,8 @@
                locals_not_used]}.
 {eunit_opts, [verbose]}.
 {plugins, [
-   { rebar3_protobuffs_plugin, {git, "git://github.com/cmkarlsson/rebar3_protobuffs_plugin", {branch, "master"}}},
+  { protobuffs, {git, "git://github.com/basho/erlang_protobuffs.git", {tag, "0.9.0"}}},
+  { rebar3_protobuffs_plugin, {git, "git://github.com/cmkarlsson/rebar3_protobuffs_plugin", {branch, "master"}}},
   { riak_pb_msgcodegen, {git, "git://github.com/tsloughter/riak_pb_msgcodegen",
      {branch, "master"}}}
 ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,8 @@
 [{<<"meck">>,
-  {git,"git://github.com/basho/meck.git",
+  {git,"https://github.com/basho/meck.git",
        {ref,"dde759050eff19a1a80fd854d7375174b191665d"}},
   1},
  {<<"protobuffs">>,
   {git,"git://github.com/basho/erlang_protobuffs.git",
-       {ref,"f88fc3c6881687432ddd5546b3c7b08009dfb26f"}},
+       {ref,"0dde9d3b37b7bec3a4dfb0e87684dd7039e169ab"}},
   0}].

--- a/src/antidote.proto
+++ b/src/antidote.proto
@@ -55,7 +55,12 @@ message ApbTxnProperties {
 // Object (Key) representation
 message ApbBoundObject {
   required bytes key = 1;
-  required uint32 type = 2;
+  enum CRDT_type {
+    COUNTER = 3;
+    ORSET = 4;
+    LWWREG = 5;
+  }
+  required CRDT_type type = 2;
   required bytes bucket = 3;
 }
 

--- a/src/antidote.proto
+++ b/src/antidote.proto
@@ -37,8 +37,8 @@ message ApbGetCounterResp {
 message ApbSetUpdate{
     enum SetOpType // TODO merge adds/removes
     {
-      ADD = 1;
-      REMOVE = 2;
+        ADD = 1;
+        REMOVE = 2;
     }
     required SetOpType optype = 1;
     repeated bytes adds = 2;
@@ -70,17 +70,18 @@ message ApbGetRegResp {
 
 // response:
 message ApbGetMVRegResp {
-    repeated bytes value = 1;
+    repeated bytes values = 1;
 }
 
 //------------------
 // Integer
 
 message ApbIntegerUpdate {
-    oneof operation {
-        sint64 inc = 1;
-        sint64 set = 2;
-    }
+    // choose one of the following:
+    // increment the integer
+    optional sint64 inc = 1;
+    // set the integer to a number
+    optional sint64 set = 2;
 }
 
 message ApbGetIntegerResp {
@@ -98,14 +99,12 @@ message ApbMapKey {
 
 message ApbMapUpdate {
     repeated ApbMapNestedUpdate updates = 1;
+    repeated ApbMapKey removedKeys = 2;
 }
 
 message ApbMapNestedUpdate {
     required ApbMapKey key = 1;
-    oneof operation {
-        ApbUpdateOperation update = 2;
-        bool remove = 3; // actual value does not matter, but protocol buffer has no unit type
-    }
+    required ApbUpdateOperation update = 2;
 }
 
 message ApbGetMapResp {
@@ -140,99 +139,96 @@ message ApbTxnProperties {
 
 // Object (Key) representation
 message ApbBoundObject {
-  required bytes key = 1;
-  required CRDT_type type = 2;
-  required bytes bucket = 3;
+    required bytes key = 1;
+    required CRDT_type type = 2;
+    required bytes bucket = 3;
 }
 
 // Objects to be read
 message ApbReadObjects {
-        repeated ApbBoundObject boundobjects = 1;
-        required bytes transaction_descriptor = 2;
+    repeated ApbBoundObject boundobjects = 1;
+    required bytes transaction_descriptor = 2;
 }
 
 // An Object to be updated with specified operation
 message ApbUpdateOp {
-        required ApbBoundObject boundobject = 1;
-        enum OPTYPE{
-        COUNTER=1;
-        SET=2;
-        REG=3;
-        }
-        required OPTYPE optype = 2;
-        optional ApbCounterUpdate counterop = 3;
-        optional ApbSetUpdate setop = 4;
-        optional ApbRegUpdate regop = 5;
+    required ApbBoundObject boundobject = 1;
+    required ApbUpdateOperation operation = 2;
 }
 
 message ApbUpdateOperation { // TODO use this above
-    oneof operation {
-        ApbCounterUpdate counterop = 1;
-        ApbSetUpdate setop = 2;
-        ApbRegUpdate regop = 3;
-    }
+    optional ApbCounterUpdate counterop = 1;
+    optional ApbSetUpdate setop = 2;
+    optional ApbRegUpdate regop = 3;
+    optional ApbIntegerUpdate integerop = 4;
+    optional ApbMapUpdate mapop = 5;
+    optional ApbCrdtReset resetop = 6;
 }
 
 // Objects to be updated
 message ApbUpdateObjects {
-        repeated ApbUpdateOp updates = 1;
-        required bytes transaction_descriptor = 2;
+    repeated ApbUpdateOp updates = 1;
+    required bytes transaction_descriptor = 2;
 }
 
 // Start Transaction
 message ApbStartTransaction {
-        optional bytes timestamp = 1;
-        optional ApbTxnProperties properties = 2;
+    optional bytes timestamp = 1;
+    optional ApbTxnProperties properties = 2;
 }
 
 // Abort Transaction
 message ApbAbortTransaction {
-        required bytes transaction_descriptor = 1;
+    required bytes transaction_descriptor = 1;
 }
 
 // Commit Transaction
 message ApbCommitTransaction {
-        required bytes transaction_descriptor = 1;
+    required bytes transaction_descriptor = 1;
 }
 
 
 message ApbStaticUpdateObjects{
-	required ApbStartTransaction transaction = 1;
-	repeated ApbUpdateOp updates = 2;
+    required ApbStartTransaction transaction = 1;
+    repeated ApbUpdateOp updates = 2;
 }
 
 message ApbStaticReadObjects{
-	required ApbStartTransaction transaction = 1;
-	repeated ApbBoundObject objects = 2;
+    required ApbStartTransaction transaction = 1;
+    repeated ApbBoundObject objects = 2;
 }
 
 //Start transaction response
 message ApbStartTransactionResp {
-        required bool success = 1;
-        optional bytes transaction_descriptor = 2;
-        optional uint32 errorcode = 3;
+    required bool success = 1;
+    optional bytes transaction_descriptor = 2;
+    optional uint32 errorcode = 3;
 }
 
 //Read Objects Response
-message ApbReadObjectResp { // TODO use oneOf
-        optional ApbGetCounterResp counter = 1;
-        optional ApbGetSetResp set = 2;
-        optional ApbGetRegResp reg = 3;
+message ApbReadObjectResp {
+    // one of the following:
+    optional ApbGetCounterResp counter = 1;
+    optional ApbGetSetResp set = 2;
+    optional ApbGetRegResp reg = 3;
+    optional ApbGetMVRegResp mvreg = 4;
+    optional ApbGetIntegerResp int = 5;
+    optional ApbGetMapResp map = 6;
 }
 message ApbReadObjectsResp {
-        required bool success = 1;
-        repeated ApbReadObjectResp objects = 2;
-        optional uint32 errorcode = 3;
+    required bool success = 1;
+    repeated ApbReadObjectResp objects = 2;
+    optional uint32 errorcode = 3;
 }
 
 // Commit Response
 message ApbCommitResp {
-        required bool success = 1;
-        optional bytes commit_time = 2;
-        optional uint32 errorcode = 3;
+    required bool success = 1;
+    optional bytes commit_time = 2;
+    optional uint32 errorcode = 3;
 }
 
 message ApbStaticReadObjectsResp {
-	required ApbReadObjectsResp objects = 1;
-	required ApbCommitResp committime = 2;
+    required ApbReadObjectsResp objects = 1;
+    required ApbCommitResp committime = 2;
 }

--- a/src/antidote.proto
+++ b/src/antidote.proto
@@ -2,15 +2,21 @@
 option java_package = "com.basho.riak.protobuf";
 option java_outer_classname = "AntidotePB";
 
-// Counter increment requenst
-message ApbRegUpdate {
-    required bytes value = 1;
+
+enum CRDT_type {
+    COUNTER = 3;
+    ORSET = 4;
+    LWWREG = 5;
+    MVREG = 6;
+    INTEGER = 7;
+    GMAP = 8;
+    AWMAP = 9;
+    RWSET = 10;
 }
 
-// Response operation
-message ApbGetRegResp {
-    required bytes value = 1;
-}
+
+//------------------
+// Counter
 
 // Counter increment requenst
 message ApbCounterUpdate {
@@ -23,15 +29,13 @@ message ApbGetCounterResp {
     required sint32 value = 1;
 }
 
-// Response operation
-message ApbOperationResp {
-    required bool success = 1;
-    optional uint32 errorcode = 2;
-}
+
+//------------------
+// Set
 
 // Set updates request
 message ApbSetUpdate{
-    enum SetOpType
+    enum SetOpType // TODO merge adds/removes
     {
       ADD = 1;
       REMOVE = 2;
@@ -46,6 +50,86 @@ message ApbGetSetResp {
     repeated bytes value = 1;
 }
 
+//------------------
+// LWW-register
+
+// Register update
+message ApbRegUpdate {
+    required bytes value = 1;
+}
+
+// Response operation
+message ApbGetRegResp {
+    required bytes value = 1;
+}
+
+//------------------
+// MV-register
+
+// use ApbRegUpdate for updates
+
+// response:
+message ApbGetMVRegResp {
+    repeated bytes value = 1;
+}
+
+//------------------
+// Integer
+
+message ApbIntegerUpdate {
+    oneof operation {
+        sint64 inc = 1;
+        sint64 set = 2;
+    }
+}
+
+message ApbGetIntegerResp {
+    required sint64 value = 1;
+}
+
+//------------------
+// Map
+
+
+message ApbMapKey {
+    required bytes key = 1;
+    required CRDT_type type = 2;
+}
+
+message ApbMapUpdate {
+    repeated ApbMapNestedUpdate updates = 1;
+}
+
+message ApbMapNestedUpdate {
+    required ApbMapKey key = 1;
+    oneof operation {
+        ApbUpdateOperation update = 2;
+        bool remove = 3; // actual value does not matter, but protocol buffer has no unit type
+    }
+}
+
+message ApbGetMapResp {
+    repeated ApbMapEntry entries = 1;
+}
+
+message ApbMapEntry {
+    required ApbMapKey key = 1;
+    required ApbReadObjectResp value = 2;
+}
+
+
+// General reset operation
+message ApbCrdtReset {
+
+}
+
+// Response operation
+message ApbOperationResp {
+    required bool success = 1;
+    optional uint32 errorcode = 2;
+}
+
+
 //--------------------------------------------------------------
 
 // Properties parameters of a transaction
@@ -57,11 +141,6 @@ message ApbTxnProperties {
 // Object (Key) representation
 message ApbBoundObject {
   required bytes key = 1;
-  enum CRDT_type {
-    COUNTER = 3;
-    ORSET = 4;
-    LWWREG = 5;
-  }
   required CRDT_type type = 2;
   required bytes bucket = 3;
 }
@@ -84,6 +163,14 @@ message ApbUpdateOp {
         optional ApbCounterUpdate counterop = 3;
         optional ApbSetUpdate setop = 4;
         optional ApbRegUpdate regop = 5;
+}
+
+message ApbUpdateOperation { // TODO use this above
+    oneof operation {
+        ApbCounterUpdate counterop = 1;
+        ApbSetUpdate setop = 2;
+        ApbRegUpdate regop = 3;
+    }
 }
 
 // Objects to be updated
@@ -127,7 +214,7 @@ message ApbStartTransactionResp {
 }
 
 //Read Objects Response
-message ApbReadObjectResp {
+message ApbReadObjectResp { // TODO use oneOf
         optional ApbGetCounterResp counter = 1;
         optional ApbGetSetResp set = 2;
         optional ApbGetRegResp reg = 3;

--- a/src/antidote.proto
+++ b/src/antidote.proto
@@ -15,9 +15,8 @@ message ApbGetRegResp {
 
 // Counter increment requenst
 message ApbCounterUpdate {
-    required uint32 optype = 1;
-    optional uint32 inc = 2;
-    optional uint32 dec = 3;
+    // inc indicates the value to be incremented. To decrement, use a negative value. If no value is given, it will be considered as an increment by 1
+    optional sint64 inc = 1;
 }
 
 // Response operation
@@ -33,15 +32,19 @@ message ApbOperationResp {
 
 // Set updates request
 message ApbSetUpdate{
-    //Optype: add = 1, add_all = 2, remove = 3, remove_all = 4
-    required uint32 optype = 1;
+    enum SetOpType
+    {
+      ADD = 1;
+      REMOVE = 2;
+    }
+    required SetOpType optype = 1;
     repeated bytes adds = 2;
     repeated bytes rems = 3;
 }
 
 // Get set request
 message ApbGetSetResp {
-    required bytes value = 1;
+    repeated bytes value = 1;
 }
 
 //--------------------------------------------------------------

--- a/src/antidote.proto
+++ b/src/antidote.proto
@@ -90,7 +90,7 @@ message ApbUpdateObjects {
 
 // Start Transaction
 message ApbStartTransaction {
-        required bytes timestamp = 1;
+        optional bytes timestamp = 1;
         optional ApbTxnProperties properties = 2;
 }
 

--- a/src/antidote.proto
+++ b/src/antidote.proto
@@ -4,8 +4,7 @@ option java_outer_classname = "AntidotePB";
 
 // Counter increment requenst
 message ApbRegUpdate {
-    required uint32 optype = 1;
-    required bytes value = 2;
+    required bytes value = 1;
 }
 
 // Response operation
@@ -76,7 +75,12 @@ message ApbReadObjects {
 // An Object to be updated with specified operation
 message ApbUpdateOp {
         required ApbBoundObject boundobject = 1;
-        required uint32 optype = 2; // Identifies which type update, 1=counter, 2=set
+        enum OPTYPE{
+        COUNTER=1;
+        SET=2;
+        REG=3;
+        }
+        required OPTYPE optype = 2;
         optional ApbCounterUpdate counterop = 3;
         optional ApbSetUpdate setop = 4;
         optional ApbRegUpdate regop = 5;

--- a/src/antidote_pb_codec.erl
+++ b/src/antidote_pb_codec.erl
@@ -63,11 +63,11 @@ encode(update_op, {Object={_Key, Type, _Bucket}, Op, Param}) ->
     EncObject = encode(bound_object, Object),
     case Type of
         antidote_crdt_counter -> EncUp = encode(counter_update, {Op, Param}),
-                                 #apbupdateop{boundobject=EncObject, optype = 1, counterop = EncUp};
+                                 #apbupdateop{boundobject=EncObject, optype = 'COUNTER', counterop = EncUp};
         antidote_crdt_orset -> SetUp = encode(set_update, {Op, Param}),
-                               #apbupdateop{boundobject=EncObject, optype = 2, setop=SetUp};
+                               #apbupdateop{boundobject=EncObject, optype = 'SET', setop=SetUp};
         antidote_crdt_lwwreg -> EncUp = encode(reg_update, {Op, Param}),
-                                #apbupdateop{boundobject=EncObject, optype = 3, regop = EncUp}
+                                #apbupdateop{boundobject=EncObject, optype = 'REG', regop = EncUp}
 
     end;
 
@@ -87,7 +87,7 @@ encode(type, antidote_crdt_orset) -> 'ORSET';
 encode(type, antidote_crdt_lwwreg) -> 'LWWREG';
 
 encode(reg_update, {assign, Value}) ->
-    #apbregupdate{optype = 1, value=Value};
+    #apbregupdate{value=Value};
 
 encode(counter_update, {increment, Amount}) ->
     #apbcounterupdate{inc = Amount};
@@ -199,7 +199,7 @@ decode(update_object, #apbupdateop{boundobject = Object, optype = OpType, counte
                      decode(reg_update, RegOp)
     end,
     {decode(bound_object, Object), Op, OpParam};
-decode(reg_update, #apbregupdate{optype = _Op, value =Value}) ->
+decode(reg_update, #apbregupdate{value =Value}) ->
     {assign, Value};
 decode(counter_update, #apbcounterupdate{inc = I}) ->
     case I of

--- a/src/antidote_pb_codec.erl
+++ b/src/antidote_pb_codec.erl
@@ -191,11 +191,11 @@ decode(error_code, 1) -> timeout;
 decode(update_object, #apbupdateop{boundobject = Object, optype = OpType, counterop = CounterOp, setop = SetOp,
                 regop = RegOp}) ->
     {Op, OpParam} = case OpType of
-                 1 ->
+                 'COUNTER' ->
                      decode(counter_update, CounterOp);
-                 2 ->
+                 'SET' ->
                      decode(set_update, SetOp);
-                 3 ->
+                 'REG' ->
                      decode(reg_update, RegOp)
     end,
     {decode(bound_object, Object), Op, OpParam};

--- a/src/antidote_pb_codec.erl
+++ b/src/antidote_pb_codec.erl
@@ -34,8 +34,14 @@
 -define(TYPE_SET, set).
 
 encode(start_transaction, {Clock, Properties}) ->
-    #apbstarttransaction{timestamp=Clock,
+    case Clock of
+      ignore ->
+              #apbstarttransaction{
                          properties = encode(txn_properties, Properties)};
+      _ ->
+              #apbstarttransaction{timestamp=Clock,
+                         properties = encode(txn_properties, Properties)}
+    end;
 
 encode(txn_properties, _) ->
  %%TODO: Add more property paramaeters

--- a/src/antidote_pb_codec.erl
+++ b/src/antidote_pb_codec.erl
@@ -27,235 +27,228 @@
 -endif.
 
 -export([encode/2,
-         decode/2,
-         decode_response/1]).
+  decode/2,
+  decode_response/1, encode_read_objects/2, decode_bound_object/1, encode_update_objects/2, decode_update_op/1]).
 
 -define(TYPE_COUNTER, counter).
 -define(TYPE_SET, set).
 
+% general encode function
 encode(start_transaction, {Clock, Properties}) ->
-    case Clock of
-      ignore ->
-              #apbstarttransaction{
-                         properties = encode(txn_properties, Properties)};
-      _ ->
-              #apbstarttransaction{timestamp=Clock,
-                         properties = encode(txn_properties, Properties)}
-    end;
-
-encode(txn_properties, _) ->
- %%TODO: Add more property paramaeters
- #apbtxnproperties{};
-
+  encode_start_transaction(Clock, Properties);
+encode(txn_properties, Props) ->
+  encode_txn_properties(Props);
 encode(abort_transaction, TxId) ->
-    #apbaborttransaction{transaction_descriptor = TxId};
-
+  encode_abort_transaction(TxId);
 encode(commit_transaction, TxId) ->
-    #apbcommittransaction{transaction_descriptor = TxId};
-
+  encode_commit_transaction(TxId);
 encode(update_objects, {Updates, TxId}) ->
-   EncUpdates = lists:map(fun(Update) ->
-                                  encode(update_op, Update) end,
-                          Updates),
-   #apbupdateobjects{ updates = EncUpdates, transaction_descriptor = TxId};
-
-encode(update_op, {Object={_Key, Type, _Bucket}, Op, Param}) ->
-    EncObject = encode(bound_object, Object),
-    case Type of
-        antidote_crdt_counter -> EncUp = encode(counter_update, {Op, Param}),
-                                 #apbupdateop{boundobject=EncObject, optype = 'COUNTER', counterop = EncUp};
-        antidote_crdt_orset -> SetUp = encode(set_update, {Op, Param}),
-                               #apbupdateop{boundobject=EncObject, optype = 'SET', setop=SetUp};
-        antidote_crdt_lwwreg -> EncUp = encode(reg_update, {Op, Param}),
-                                #apbupdateop{boundobject=EncObject, optype = 'REG', regop = EncUp}
-
-    end;
-
+  encode_update_objects(Updates, TxId);
+encode(update_op, {Object, Op, Param}) ->
+  encode_update_op(Object, Op, Param);
 encode(static_update_objects, {Clock, Properties, Updates}) ->
-    EncTransaction = encode(start_transaction, {Clock, Properties}),
-    EncUpdates = lists:map(fun(Update) ->
-                                  encode(update_op, Update) end,
-                          Updates),
-    #apbstaticupdateobjects{transaction = EncTransaction,
-                            updates = EncUpdates};
-
+  encode_static_update_objects(Clock, Properties, Updates);
 encode(bound_object, {Key, Type, Bucket}) ->
-    #apbboundobject{key=Key, type=encode(type,Type), bucket=Bucket};
-
-encode(type, antidote_crdt_counter) -> 'COUNTER';
-encode(type, antidote_crdt_orset) -> 'ORSET';
-encode(type, antidote_crdt_lwwreg) -> 'LWWREG';
-
-encode(reg_update, {assign, Value}) ->
-    #apbregupdate{value=Value};
-
-encode(counter_update, {increment, Amount}) ->
-    #apbcounterupdate{inc = Amount};
-
-encode(counter_update, {decrement, Amount}) ->
-    #apbcounterupdate{inc= -Amount};
-
-encode(set_update, {add, Elem}) ->
-    #apbsetupdate{optype = 'ADD', adds = [term_to_binary(Elem)]};
-encode(set_update, {add_all, Elems}) ->
-    BinElems = lists:map(fun(Elem) ->
-                                term_to_binary(Elem)
-                        end,
-                        Elems),
-    #apbsetupdate{optype = 'ADD', adds = BinElems};
-encode(set_update, {remove, Elem}) ->
-    #apbsetupdate{optype= 'REMOVE', rems = [term_to_binary(Elem)]};
-encode(set_update, {remove_all, Elems}) ->
-    BinElems = lists:map(fun(Elem) ->
-                                term_to_binary(Elem)
-                        end,
-                        Elems),
-    #apbsetupdate{optype = 'REMOVE', rems = BinElems};
-
-
+  encode_bound_object(Key, Type, Bucket);
+encode(type, Type) ->
+  encode_type(Type);
+encode(reg_update, Update) ->
+  encode_reg_update(Update);
+encode(counter_update, Update) ->
+  encode_counter_update(Update);
+encode(set_update, Update) ->
+  encode_set_update(Update);
 encode(read_objects, {Objects, TxId}) ->
-    BoundObjects = lists:map(fun(Object) ->
-                                     encode(bound_object, Object) end,
-                             Objects),
-    #apbreadobjects{boundobjects = BoundObjects, transaction_descriptor = TxId};
-
-
+  encode_read_objects(Objects, TxId);
 encode(static_read_objects, {Clock, Properties, Objects}) ->
-    EncTransaction = encode(start_transaction, {Clock, Properties}),
-    EncObjects = lists:map(fun(Object) ->
-                                     encode(bound_object, Object) end,
-                             Objects),
-    #apbstaticreadobjects{transaction = EncTransaction,
-                          objects = EncObjects};
-
-encode(start_transaction_response, {error, Reason}) ->
-    #apbstarttransactionresp{success=false, errorcode = encode(error_code, Reason)};
-
-encode(start_transaction_response, {ok, TxId}) ->
-    #apbstarttransactionresp{success=true, transaction_descriptor=term_to_binary(TxId)};
-
-encode(operation_response, {error, Reason}) ->
-    #apboperationresp{success=false, errorcode = encode(error_code, Reason)};
-
-encode(operation_response, ok) ->
-    #apboperationresp{success=true};
-
-encode(commit_response, {error, Reason}) ->
-    #apbcommitresp{success=false, errorcode = encode(error_code, Reason)};
-
-encode(commit_response, {ok, CommitTime}) ->
-    #apbcommitresp{success=true, commit_time= term_to_binary(CommitTime)};
-
-encode(read_objects_response, {error, Reason}) ->
-    #apbreadobjectsresp{success=false, errorcode = encode(error_code, Reason)};
-
-encode(read_objects_response, {ok, Results}) ->
-    EncResults = lists:map(fun(R) ->
-                                   encode(read_object_resp, R) end,
-                           Results),
-    #apbreadobjectsresp{success=true, objects = EncResults};
-
-encode(read_object_resp, {{_Key, antidote_crdt_lwwreg, _Bucket}, Val}) ->
-    #apbreadobjectresp{reg=#apbgetregresp{value=term_to_binary(Val)}};
-
-encode(read_object_resp, {{_Key, antidote_crdt_counter, _Bucket}, Val}) ->
-    #apbreadobjectresp{counter=#apbgetcounterresp{value=Val}};
-
-encode(read_object_resp, {{_Key, antidote_crdt_orset, _Bucket}, Val}) ->
-    #apbreadobjectresp{set=#apbgetsetresp{value=Val}};
-
+  encode_static_read_objects(Clock, Properties, Objects);
+encode(start_transaction_response, Resp) ->
+  encode_start_transaction_response(Resp);
+encode(operation_response, Resp) ->
+  encode_operation_response(Resp);
+encode(commit_response, Resp) ->
+  encode_commit_response(Resp);
+encode(read_objects_response, Resp) ->
+  encode_read_objects_response(Resp);
+encode(read_object_resp, Resp) ->
+  encode_read_object_resp(Resp);
 encode(static_read_objects_response, {ok, Results, CommitTime}) ->
-    #apbstaticreadobjectsresp{
-       objects = encode(read_objects_response, {ok, Results}),
-       committime = encode(commit_response, {ok, CommitTime})};
-
-%% Add new error codes
-encode(error_code, unknown) -> 0;
-encode(error_code, timeout) -> 1;
-encode(error_code, _Other) -> 0;
-
+  encode_static_read_objects_response(Results, CommitTime);
+encode(error_code, Code) ->
+  encode_error_code(Code);
 encode(_Other, _) ->
     erlang:error("Incorrect operation/Not yet implemented").
 
-decode(txn_properties, _Properties) ->
-    {};
-decode(bound_object, #apbboundobject{key = Key, type=Type, bucket=Bucket}) ->
-    {Key, decode(type, Type), Bucket};
-
-decode(type, 'COUNTER') -> antidote_crdt_counter;
-decode(type, 'ORSET') -> antidote_crdt_orset;
-decode(type, 'LWWREG') -> antidote_crdt_lwwreg;
-decode(error_code, 0) -> unknown;
-decode(error_code, 1) -> timeout;
-
-decode(update_object, #apbupdateop{boundobject = Object, optype = OpType, counterop = CounterOp, setop = SetOp,
-                regop = RegOp}) ->
-    {Op, OpParam} = case OpType of
-                 'COUNTER' ->
-                     decode(counter_update, CounterOp);
-                 'SET' ->
-                     decode(set_update, SetOp);
-                 'REG' ->
-                     decode(reg_update, RegOp)
-    end,
-    {decode(bound_object, Object), Op, OpParam};
-decode(reg_update, #apbregupdate{value =Value}) ->
-    {assign, Value};
-decode(counter_update, #apbcounterupdate{inc = I}) ->
-    case I of
-        undefined -> {increment, 1};
-        I ->  {increment, I} % negative value for I indicates decrement
-    end;
-
-decode(set_update, #apbsetupdate{optype = OpType, adds = A, rems = R}) ->
-  case OpType  of
-      'ADD' ->
-          OpsAdd =  case A of
-                      undefined -> [];
-                      AddElems when is_list(AddElems)-> {add_all, AddElems}
-                    end,
-          OpsAdd;
-      'REMOVE' ->
-          OpsRem = case R of
-                      undefined -> [];
-                      Elems when is_list(Elems) -> {remove_all, Elems}
-                    end,
-          OpsRem
-      end;
-
+% general decode function
+decode(txn_properties, Properties) ->
+  decode_txn_properties(Properties);
+decode(bound_object, Obj) ->
+  decode_bound_object(Obj);
+decode(type, Type) ->
+  decode_type(Type);
+decode(error_code, Code) ->
+  decode_error_code(Code);
+decode(update_object, Obj) ->
+  decode_update_op(Obj);
+decode(reg_update, Update) ->
+  decode_reg_update(Update);
+decode(counter_update, Update) ->
+  decode_counter_update(Update);
+decode(set_update, Update) ->
+  decode_set_update(Update);
 decode(_Other, _) ->
     erlang:error("Unknown message").
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% error codes
+
+encode_error_code(unknown) -> 0;
+encode_error_code(timeout) -> 1;
+encode_error_code(_Other) -> 0.
+
+decode_error_code(0) -> unknown;
+decode_error_code(1) -> timeout.
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%
+% Transactions
+
+encode_start_transaction(Clock, Properties) ->
+  case Clock of
+    ignore ->
+      #apbstarttransaction{
+        properties = encode_txn_properties(Properties)};
+    _ ->
+      #apbstarttransaction{timestamp = Clock,
+        properties = encode_txn_properties(Properties)}
+  end.
+
+
+encode_commit_transaction(TxId) ->
+  #apbcommittransaction{transaction_descriptor = TxId}.
+
+encode_abort_transaction(TxId) ->
+  #apbaborttransaction{transaction_descriptor = TxId}.
+
+
+encode_txn_properties(_Props) ->
+  %%TODO: Add more property parameters
+  #apbtxnproperties{}.
+
+decode_txn_properties(_Properties) ->
+  {}.
+
+
+
+%%%%%%%%%%%%%%%%%%%%%
+%% Updates
+
+% bound objects
+
+encode_bound_object({Key, Type, Bucket}) ->
+  encode_bound_object(Key, Type, Bucket).
+encode_bound_object(Key, Type, Bucket) ->
+  #apbboundobject{key = Key, type = encode_type(Type), bucket = Bucket}.
+
+decode_bound_object(Obj) ->
+  #apbboundobject{key = Key, type = Type, bucket = Bucket} = Obj,
+  {Key, decode_type(Type), Bucket}.
+
+
+% static_update_objects
+
+encode_static_update_objects(Clock, Properties, Updates) ->
+  EncTransaction = encode_start_transaction(Clock, Properties),
+  EncUpdates = lists:map(fun(Update) ->
+    encode_update_op(Update) end,
+    Updates),
+  #apbstaticupdateobjects{transaction = EncTransaction,
+    updates = EncUpdates}.
+
+
+decode_update_op(Obj) ->
+  #apbupdateop{boundobject = Object, optype = OpType, counterop = CounterOp, setop = SetOp,
+    regop = RegOp} = Obj,
+  {Op, OpParam} = case OpType of
+                    'COUNTER' ->
+                      decode_counter_update(CounterOp);
+                    'SET' ->
+                      decode_set_update(SetOp);
+                    'REG' ->
+                      decode_reg_update(RegOp)
+                  end,
+  {decode_bound_object(Object), Op, OpParam}.
+
+
+
+encode_update_objects(Updates, TxId) ->
+  EncUpdates = lists:map(fun(Update) ->
+    encode_update_op(Update) end,
+    Updates),
+  #apbupdateobjects{updates = EncUpdates, transaction_descriptor = TxId}.
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%
+%% Responses
+
+encode_static_read_objects_response(Results, CommitTime) ->
+  #apbstaticreadobjectsresp{
+    objects = encode_read_objects_response({ok, Results}),
+    committime = encode_commit_response({ok, CommitTime})}.
+
+
+encode_read_objects_response({error, Reason}) ->
+    #apbreadobjectsresp{success=false, errorcode = encode_error_code(Reason)};
+encode_read_objects_response({ok, Results}) ->
+    EncResults = lists:map(fun(R) ->
+                                   encode_read_object_resp(R) end,
+                           Results),
+    #apbreadobjectsresp{success=true, objects = EncResults}.
+
+
+encode_start_transaction_response({error, Reason}) ->
+  #apbstarttransactionresp{success = false, errorcode = encode_error_code(Reason)};
+encode_start_transaction_response({ok, TxId}) ->
+  #apbstarttransactionresp{success = true, transaction_descriptor = term_to_binary(TxId)}.
+
+encode_operation_response({error, Reason}) ->
+    #apboperationresp{success=false, errorcode = encode_error_code(Reason)};
+encode_operation_response(ok) ->
+    #apboperationresp{success=true}.
+
+encode_commit_response({error, Reason}) ->
+    #apbcommitresp{success=false, errorcode = encode_error_code(Reason)};
+
+encode_commit_response({ok, CommitTime}) ->
+    #apbcommitresp{success=true, commit_time= term_to_binary(CommitTime)}.
 
 decode_response(#apboperationresp{success = true}) ->
     {opresponse, ok};
 decode_response(#apboperationresp{success = false, errorcode = Reason})->
-    {error, decode(error_code, Reason)};
+    {error, decode_error_code(Reason)};
 decode_response(#apbstarttransactionresp{success=true,
                                          transaction_descriptor = TxId}) ->
     {start_transaction, TxId};
 decode_response(#apbstarttransactionresp{success=false, errorcode = Reason}) ->
-    {error, decode(error_code, Reason)};
+    {error, decode_error_code(Reason)};
 decode_response(#apbcommitresp{success=true, commit_time = TimeStamp}) ->
     {commit_transaction, TimeStamp};
 decode_response(#apbcommitresp{success=false, errorcode = Reason}) ->
-    {error, decode(error_code, Reason)};
+    {error, decode_error_code(Reason)};
 decode_response(#apbreadobjectsresp{success=false, errorcode=Reason}) ->
-    {error, decode(error_code, Reason)};
+    {error, decode_error_code(Reason)};
 decode_response(#apbreadobjectsresp{success=true, objects = Objects}) ->
     Resps = lists:map(fun(O) ->
                               decode_response(O) end,
                       Objects),
     {read_objects, Resps};
-decode_response(#apbreadobjectresp{counter = #apbgetcounterresp{value = Val}}) ->
-    {counter, Val};
-decode_response(#apbreadobjectresp{set = #apbgetsetresp{value = Val}}) ->
-    Res = lists:map(fun(Elem) ->
-                              binary_to_term(Elem)
-                    end,
-                    Val),
-    {set, Res};
-decode_response(#apbreadobjectresp{reg = #apbgetregresp{value = Val}}) ->
-    {reg, erlang:binary_to_term(Val)};
+decode_response(#apbreadobjectresp{}=ReadObjectResp) ->
+  decode_read_object_resp(ReadObjectResp);
 decode_response(#apbstaticreadobjectsresp{objects = Objects,
                                           committime = CommitTime}) ->
     {read_objects, Values} = decode_response(Objects),
@@ -263,6 +256,147 @@ decode_response(#apbstaticreadobjectsresp{objects = Objects,
     {static_read_objects_resp, Values, TimeStamp};
 decode_response(Other) ->
     erlang:error("Unexpected message: ~p",[Other]).
+
+%%%%%%%%%%%%%%%%%%%%%%
+%% Reading objects
+
+
+encode_static_read_objects(Clock, Properties, Objects) ->
+  EncTransaction = encode_start_transaction(Clock, Properties),
+  EncObjects = lists:map(fun(Object) ->
+    encode_bound_object(Object) end,
+    Objects),
+  #apbstaticreadobjects{transaction = EncTransaction,
+    objects = EncObjects}.
+
+encode_read_objects(Objects, TxId) ->
+  BoundObjects = lists:map(fun(Object) ->
+    encode_bound_object(Object) end,
+    Objects),
+  #apbreadobjects{boundobjects = BoundObjects, transaction_descriptor = TxId}.
+
+%%%%%%%%%%%%%%%%%%%
+%% Crdt types
+
+encode_type(antidote_crdt_counter) -> 'COUNTER';
+encode_type(antidote_crdt_orset) -> 'ORSET';
+encode_type(antidote_crdt_lwwreg) -> 'LWWREG'.
+
+decode_type('COUNTER') -> antidote_crdt_counter;
+decode_type('ORSET') -> antidote_crdt_orset;
+decode_type('LWWREG') -> antidote_crdt_lwwreg.
+
+
+%%%%%%%%%%%%%%%%%%%%%%
+% CRDT operations
+
+% general encoding of a CRDT operation
+encode_update_op({Object, Op, Param}) ->
+  encode_update_op(Object, Op, Param).
+encode_update_op(Object, Op, Param) ->
+  {_Key, Type, _Bucket} = Object,
+  EncObject = encode_bound_object(Object),
+  case Type of
+    antidote_crdt_counter -> EncUp = encode_counter_update({Op, Param}),
+      #apbupdateop{boundobject = EncObject, optype = 'COUNTER', counterop = EncUp};
+    antidote_crdt_orset -> SetUp = encode_set_update({Op, Param}),
+      #apbupdateop{boundobject = EncObject, optype = 'SET', setop = SetUp};
+    antidote_crdt_lwwreg -> EncUp = encode_reg_update({Op, Param}),
+      #apbupdateop{boundobject = EncObject, optype = 'REG', regop = EncUp}
+
+  end.
+
+% general encoding of CRDT responses
+
+encode_read_object_resp({{_Key, Type, _Bucket}, Val}) ->
+  encode_read_object_resp(Type, Val).
+
+encode_read_object_resp(antidote_crdt_lwwreg, Val) ->
+    #apbreadobjectresp{reg=#apbgetregresp{value=term_to_binary(Val)}};
+encode_read_object_resp(antidote_crdt_counter, Val) ->
+    #apbreadobjectresp{counter=#apbgetcounterresp{value=Val}};
+encode_read_object_resp(antidote_crdt_orset, Val) ->
+    #apbreadobjectresp{set=#apbgetsetresp{value=Val}}.
+
+
+% TODO why does this use counter instead of antidote_crdt_counter etc.?
+decode_read_object_resp(#apbreadobjectresp{counter = #apbgetcounterresp{value = Val}}) ->
+    {counter, Val};
+decode_read_object_resp(#apbreadobjectresp{set = #apbgetsetresp{value = Val}}) ->
+    Res = lists:map(fun(Elem) ->
+                              binary_to_term(Elem)
+                    end,
+                    Val),
+    {set, Res};
+decode_read_object_resp(#apbreadobjectresp{reg = #apbgetregresp{value = Val}}) ->
+    {reg, erlang:binary_to_term(Val)}.
+
+
+% set updates
+
+encode_set_update({add, Elem}) ->
+    #apbsetupdate{optype = 'ADD', adds = [term_to_binary(Elem)]};
+encode_set_update({add_all, Elems}) ->
+    BinElems = lists:map(fun(Elem) ->
+                                term_to_binary(Elem)
+                        end,
+                        Elems),
+    #apbsetupdate{optype = 'ADD', adds = BinElems};
+encode_set_update({remove, Elem}) ->
+    #apbsetupdate{optype= 'REMOVE', rems = [term_to_binary(Elem)]};
+encode_set_update({remove_all, Elems}) ->
+    BinElems = lists:map(fun(Elem) ->
+                                term_to_binary(Elem)
+                        end,
+                        Elems),
+    #apbsetupdate{optype = 'REMOVE', rems = BinElems}.
+
+decode_set_update(Update) ->
+  #apbsetupdate{optype = OpType, adds = A, rems = R} = Update,
+  case OpType of
+    'ADD' ->
+      OpsAdd = case A of
+                 undefined -> [];
+                 AddElems when is_list(AddElems) -> {add_all, AddElems}
+               end,
+      OpsAdd;
+    'REMOVE' ->
+      OpsRem = case R of
+                 undefined -> [];
+                 Elems when is_list(Elems) -> {remove_all, Elems}
+               end,
+      OpsRem
+  end.
+
+% counter updates
+
+encode_counter_update({increment, Amount}) ->
+  #apbcounterupdate{inc = Amount};
+encode_counter_update({decrement, Amount}) ->
+  #apbcounterupdate{inc = -Amount}.
+
+
+decode_counter_update(Update) ->
+  #apbcounterupdate{inc = I} = Update,
+  case I of
+    undefined -> {increment, 1};
+    I -> {increment, I} % negative value for I indicates decrement
+  end.
+
+
+% register updates
+
+encode_reg_update(Update) ->
+  {assign, Value} = Update,
+  #apbregupdate{value = Value}.
+
+
+decode_reg_update(Update) ->
+  #apbregupdate{value = Value} = Update,
+  {assign, Value}.
+
+
+
 
 
 
@@ -287,13 +421,13 @@ read_transaction_test() ->
                {<<"key2">>, antidote_crdt_orset, <<"bucket2">>}],
     TxId = term_to_binary({12}),
          %% Dummy value, structure of TxId is opaque to client
-    EncRecord = antidote_pb_codec:encode(read_objects, {Objects, TxId}),
+    EncRecord = antidote_pb_codec:encode_read_objects(Objects, TxId),
     ?assertMatch(true, is_record(EncRecord, apbreadobjects)),
     [MsgCode, MsgData] = riak_pb_codec:encode(EncRecord),
     Msg = riak_pb_codec:decode(MsgCode, list_to_binary(MsgData)),
     ?assertMatch(true, is_record(Msg, apbreadobjects)),
     DecObjects = lists:map(fun(O) ->
-                                antidote_pb_codec:decode(bound_object, O) end,
+                                antidote_pb_codec:decode_bound_object(O) end,
                            Msg#apbreadobjects.boundobjects),
     ?assertMatch(Objects, DecObjects),
     %% Test encoding error
@@ -305,7 +439,7 @@ read_transaction_test() ->
                  antidote_pb_codec:decode_response(ErrMsg)),
 
     %% Test encoding results
-    Results = [1, [2]],
+    Results = [1, [term_to_binary(2)]],
     ResEnc = antidote_pb_codec:encode(read_objects_response,
                                       {ok, lists:zip(Objects, Results)}
                                      ),
@@ -324,15 +458,21 @@ update_types_test() ->
               ],
     TxId = term_to_binary({12}),
          %% Dummy value, structure of TxId is opaque to client
-    EncRecord = antidote_pb_codec:encode(update_objects, {Updates, TxId}),
+    EncRecord = antidote_pb_codec:encode_update_objects(Updates, TxId),
     ?assertMatch(true, is_record(EncRecord, apbupdateobjects)),
     [MsgCode, MsgData] = riak_pb_codec:encode(EncRecord),
     Msg = riak_pb_codec:decode(MsgCode, list_to_binary(MsgData)),
     ?assertMatch(true, is_record(Msg, apbupdateobjects)),
     DecUpdates = lists:map(fun(O) ->
-                                antidote_pb_codec:decode(update_object, O) end,
+                                antidote_pb_codec:decode_update_op(O) end,
                         Msg#apbupdateobjects.updates),
-    ?assertMatch(Updates, DecUpdates).
+    Expected = [ {{<<"1">>, antidote_crdt_counter, <<"2">>}, increment , 1},
+                  {{<<"2">>, antidote_crdt_counter, <<"2">>}, increment , 1},
+                  {{<<"a">>, antidote_crdt_orset, <<"2">>}, add_all , [term_to_binary(3)]},
+                  {{<<"b">>, antidote_crdt_counter, <<"2">>}, increment , 2},
+                  {{<<"c">>, antidote_crdt_orset, <<"2">>}, add_all, [term_to_binary(4)]},
+                  {{<<"a">>, antidote_crdt_orset, <<"2">>}, add_all , [term_to_binary(X) || X <- [5,6]]}],
+    ?assertMatch(Expected, DecUpdates).
 
 error_messages_test() ->
     EncRecord1 = antidote_pb_codec:encode(start_transaction_response,
@@ -356,4 +496,28 @@ error_messages_test() ->
     Resp3 = antidote_pb_codec:decode_response(Msg3),
     ?assertMatch(Resp3, {error, unknown}).
 
+-define(TestCrdtOperationCodec(Type, Op, Param),
+    ?assertEqual(
+      {{<<"key">>, Type, <<"bucket">>}, Op, Param},
+      decode_update_op(encode_update_op({<<"key">>, Type, <<"bucket">>}, Op, Param)))
+).
+
+-define(TestCrdtResponseCodec(Type, ExpectedType, Val),
+    ?assertEqual(
+      {ExpectedType, Val},
+      decode_read_object_resp(encode_read_object_resp(Type, Val)))
+).
+
+crdt_encode_decode_test() ->
+  %% encoding the following operations and decoding them again, should give the same result
+
+  ?TestCrdtOperationCodec(antidote_crdt_counter, increment, 1),
+  ?TestCrdtResponseCodec(antidote_crdt_counter, counter, 42),
+
+  ok.
+
+
+
 -endif.
+
+

--- a/src/antidote_pb_codec.erl
+++ b/src/antidote_pb_codec.erl
@@ -76,9 +76,9 @@ encode(static_update_objects, {Clock, Properties, Updates}) ->
 encode(bound_object, {Key, Type, Bucket}) ->
     #apbboundobject{key=Key, type=encode(type,Type), bucket=Bucket};
 
-encode(type, antidote_crdt_counter) -> 3;
-encode(type, antidote_crdt_orset) -> 4;
-encode(type, antidote_crdt_lwwreg) -> 5;
+encode(type, antidote_crdt_counter) -> 'COUNTER';
+encode(type, antidote_crdt_orset) -> 'ORSET';
+encode(type, antidote_crdt_lwwreg) -> 'LWWREG';
 
 encode(reg_update, {assign, Value}) ->
     #apbregupdate{optype = 1, value=Value};
@@ -176,13 +176,13 @@ decode(txn_properties, _Properties) ->
 decode(bound_object, #apbboundobject{key = Key, type=Type, bucket=Bucket}) ->
     {Key, decode(type, Type), Bucket};
 
-decode(type, 3) -> antidote_crdt_counter;
-decode(type, 4) -> antidote_crdt_orset;
-decode(type, 5) -> antidote_crdt_lwwreg;
+decode(type, 'COUNTER') -> antidote_crdt_counter;
+decode(type, 'ORSET') -> antidote_crdt_orset;
+decode(type, 'LWWREG') -> antidote_crdt_lwwreg;
 decode(error_code, 0) -> unknown;
 decode(error_code, 1) -> timeout;
 
-decode(update_object, #apbupdateop{boundobject = Object, optype = OpType, counterop = CounterOp, setop = SetOp, 
+decode(update_object, #apbupdateop{boundobject = Object, optype = OpType, counterop = CounterOp, setop = SetOp,
                 regop = RegOp}) ->
     {Op, OpParam} = case OpType of
                  1 ->


### PR DESCRIPTION
- There is now a top-level enum for CRDT types
- Usages of term_to_binary have been removed
- New datatypes were added (in particular: maps)
- ApbUpdateOp was split into two messages, so that one part can be reused for embedded messages in maps
- I removed the SetOpType for set-operations, as it can be derived from the other fields. 
- `optype` in the counter update is removed (one signed integer is enough for a counter update)
- ApbGetSetResp now contains repeated bytes instead of using term_to_binary
- I changed the structure of antidote_pb_codec and split the big encode and decode functions into several function. That has the benefit that encode and decode functions for a message can be written next to each other and more easily compared.

Related pull request: https://github.com/SyncFree/antidote_crdt/pull/2

System tests for this are in: https://github.com/SyncFree/antidote/tree/antidote_pb_fixes2 (Commit: https://github.com/SyncFree/antidote/commit/0b2af9638b2ebfc5b38a9c6c37de53e46a906d74)
