### PR TITLE
Flag-CRDTs

### DIFF
--- a/src/antidote.proto
+++ b/src/antidote.proto
@@ -14,6 +14,8 @@ enum CRDT_type {
     RWSET = 10;
     RRMAP = 11;
     FATCOUNTER = 12;
+    FLAG_EW = 13;
+    FLAG_DW = 14;
 }
 
 
@@ -118,6 +120,18 @@ message ApbMapEntry {
     required ApbReadObjectResp value = 2;
 }
 
+//-------------------
+// Flags
+
+message ApbFlagUpdate {
+    required bool value = 1;
+}
+
+message ApbGetFlagResp {
+    required bool value = 1;
+}
+
+
 
 // General reset operation
 message ApbCrdtReset {
@@ -165,6 +179,7 @@ message ApbUpdateOperation { // TODO use this above
     optional ApbIntegerUpdate integerop = 4;
     optional ApbMapUpdate mapop = 5;
     optional ApbCrdtReset resetop = 6;
+    optional ApbFlagUpdate flagop = 7;
 }
 
 // Objects to be updated
@@ -216,6 +231,7 @@ message ApbReadObjectResp {
     optional ApbGetMVRegResp mvreg = 4;
     optional ApbGetIntegerResp int = 5;
     optional ApbGetMapResp map = 6;
+    optional ApbGetFlagResp flag = 7;
 }
 message ApbReadObjectsResp {
     required bool success = 1;

--- a/src/antidote_pb_codec.erl
+++ b/src/antidote_pb_codec.erl
@@ -320,6 +320,8 @@ decode_type('RRMAP') -> antidote_crdt_map_rr.
 % CRDT operations
 
 
+encode_update_operation(_Type, {reset, {}}) ->
+  #apbupdateoperation{resetop = #apbcrdtreset{}};
 encode_update_operation(antidote_crdt_counter, Op_Param) ->
   #apbupdateoperation{counterop = encode_counter_update(Op_Param)};
 encode_update_operation(antidote_crdt_fat_counter, Op_Param) ->
@@ -352,7 +354,10 @@ decode_update_operation(#apbupdateoperation{regop = Op}) when Op /= undefined ->
 decode_update_operation(#apbupdateoperation{integerop = Op}) when Op /= undefined ->
   decode_integer_update(Op);
 decode_update_operation(#apbupdateoperation{mapop = Op}) when Op /= undefined ->
-  decode_map_update(Op).
+  decode_map_update(Op);
+decode_update_operation(#apbupdateoperation{resetop = #apbcrdtreset{}}) ->
+  {reset, {}}.
+
 
 %%decode_update_operation(#apbupdateoperation{mapop = Op}) when Op /= undefined ->
 %%  decode_map_update(Op);


### PR DESCRIPTION
This pull request adds the interface for the flag CRDTs (enable-wins- and disable-wins-flags) and adds the reset-operation.

Integration tests are on the antidote branch at https://github.com/SyncFree/antidote/tree/pb-add-flags