### PR TITLE
Handle error-response in decode_response

### DIFF
--- a/src/antidote_pb_codec.erl
+++ b/src/antidote_pb_codec.erl
@@ -273,7 +273,7 @@ decode_response(#apbgetconnectiondescriptorresponse{descriptor= Descriptor}) ->
 decode_response(#rpberrorresp{errmsg = Msg, errcode = Code}) ->
     {error, {Msg, Code}};
 decode_response(Other) ->
-    erlang:error("Unexpected message: ~p", [Other]).
+    erlang:error(unexpected_message, [Other]).
 
 %%%%%%%%%%%%%%%%%%%%%%
 %% Reading objects

--- a/src/antidote_pb_codec.erl
+++ b/src/antidote_pb_codec.erl
@@ -273,7 +273,7 @@ decode_response(#apbgetconnectiondescriptorresponse{descriptor= Descriptor}) ->
 decode_response(#rpberrorresp{errmsg = Msg, errcode = Code}) ->
     {error, {Msg, Code}};
 decode_response(Other) ->
-    erlang:error("Unexpected message.", [Other]).
+    erlang:error("Unexpected message: ~p", [Other]).
 
 %%%%%%%%%%%%%%%%%%%%%%
 %% Reading objects

--- a/src/antidote_pb_codec.erl
+++ b/src/antidote_pb_codec.erl
@@ -270,8 +270,10 @@ decode_response(#apbstaticreadobjectsresp{objects = Objects,
     {static_read_objects_resp, Values, TimeStamp};
 decode_response(#apbgetconnectiondescriptorresponse{descriptor= Descriptor}) ->
     {connection_descriptor, Descriptor};
+decode_response(#rpberrorresp{errmsg = Msg, errcode = Code}) ->
+    {error, {Msg, Code}};
 decode_response(Other) ->
-    erlang:error("Unexpected message: ~p",[Other]).
+    erlang:error("Unexpected message.", [Other]).
 
 %%%%%%%%%%%%%%%%%%%%%%
 %% Reading objects
@@ -658,6 +660,10 @@ error_messages_test() ->
     Msg3 = riak_pb_codec:decode(MsgCode3, list_to_binary(MsgData3)),
     Resp3 = antidote_pb_codec:decode_response(Msg3),
     ?assertMatch(Resp3, {error, unknown}).
+
+error_response_test() ->
+  Msg = #rpberrorresp{errmsg = <<"abc">>, errcode = 0},
+  ?assertEqual({error, {<<"abc">>, 0}}, decode_response(Msg)).
 
 -define(TestCrdtOperationCodec(Type, Op, Param),
     ?assertEqual(


### PR DESCRIPTION
This should improve the error handling when getting an error response from Antidote as happened in a recent build: 

https://travis-ci.org/SyncFree/antidote/jobs/425909202

```
Starting Test transaction
escript: exception error: "Unexpected message: ~p"
  in function  antidote_pb_codec:decode_response/1
     called as antidote_pb_codec:decode_response({rpberrorresp
                                                  <<"Unknown message code: 119">>
                                                  0})
  in call from antidotec_pb:start_transaction/3 (/home/travis/build/SyncFree/antidote/_build/default/lib/antidote_pb/src/antidotec_pb.erl, line 48)
make: *** [reltest] Error 127
```